### PR TITLE
fix: first-run setup when nothing can answer yet

### DIFF
--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -209,6 +209,12 @@ find whatever the click should have opened. Scroll first. In the test renderer
 `wheel(0, -4000)` scrolls down, since the delta moves the content, and the
 offset stops at the end of the content.
 
+### `⎋` is not in the UI font
+
+The Settings Done control used `hint="⎋"` for Escape. SF Mono paints a
+missing-glyph box. The control now uses the same `Kbd` cap as the empty
+states, labelled `esc`.
+
 ### An icon is imported, not read
 
 `import icon from "./x.svg" with { type: "text" }` hands back the file's

--- a/app.test.tsx
+++ b/app.test.tsx
@@ -81,6 +81,7 @@ import {
 import {
   ATTACHMENT_DIR,
   DEFAULT_MODEL,
+  NO_CREDENTIAL,
   DIR,
   appendMessage,
   clearNotices,
@@ -1970,7 +1971,7 @@ describeNative("fx app", () => {
     }
   })
 
-  it("takes a notice off the transcript when it is clicked", async () => {
+  it("takes a notice off the transcript when it is dismissed", async () => {
     const workspace = createWorkspace(tempDir(), "demo")
     const session = createSession(workspace.id)
     openSession(session.id, 0)
@@ -1989,10 +1990,39 @@ describeNative("fx app", () => {
     await app.getByTestId("notice-n1").click()
     await settle()
     renderer.flush()
+    expect(messagesOf(session.id).some((message) => message.kind === "notice")).toBe(true)
+
+    await app.getByTestId("notice-dismiss-n1").click()
+    await settle()
+    renderer.flush()
 
     expect(messagesOf(session.id).some((message) => message.kind === "notice")).toBe(false)
     expect(messagesOf(session.id).some((message) => message.kind === "tool")).toBe(true)
     expect(renderer.getPaintedText().join("\n")).not.toContain("HTTP 400")
+
+    await app.close()
+  })
+
+  it("opens settings from a credential notice without dismissing it", async () => {
+    const workspace = createWorkspace(tempDir(), "demo")
+    const session = createSession(workspace.id)
+    openSession(session.id, 0)
+    appendMessage(session.id, {
+      id: "n1",
+      kind: "notice",
+      at: Date.now(),
+      tone: "error",
+      text: NO_CREDENTIAL,
+      action: "settings",
+    })
+
+    const { app } = await mount()
+    await app.getByTestId("notice-settings-n1").click()
+    await settle()
+
+    expect(getState().settingsOpen).toBe(true)
+    expect(messagesOf(session.id).some((message) => message.kind === "notice")).toBe(true)
+    expect(await app.getByTestId("settings-page").count()).toBe(1)
 
     await app.close()
   })
@@ -3381,6 +3411,13 @@ describeNative("fx app", () => {
     const { renderer, app } = await mount()
 
     expect(getState().sessions[0]?.model).toBeNull()
+    if (!process.env.AI_GATEWAY_API_KEY) {
+      expect(renderer.getPaintedText().join("\n")).toContain("No model")
+      expect(renderer.getPaintedText().join("\n")).not.toContain(DEFAULT_MODEL.name)
+      setState((current) => ({ ...current, apiKey: "vck_x" }))
+      await settle()
+      renderer.flush()
+    }
     expect(renderer.getPaintedText().join("\n")).toContain(DEFAULT_MODEL.name)
 
     await app.close()
@@ -3457,6 +3494,54 @@ describeNative("fx app", () => {
     expect(renderer.getPaintedText().join("\n")).toContain("Grok")
 
     await app.close()
+  })
+
+  it("points a new session at settings when nothing can answer", async () => {
+    if (process.env.AI_GATEWAY_API_KEY) return
+    const workspace = createWorkspace(tempDir(), "demo")
+    openSession(createSession(workspace.id).id, 0)
+    const { renderer, app } = await mount()
+
+    expect(renderer.getPaintedText().join("\n")).toContain("Nothing can answer yet")
+    await app.getByTestId("empty-setup").click()
+    await settle()
+    renderer.flush()
+    expect(await app.getByTestId("settings-page").count()).toBe(1)
+    expect(await app.getByTestId("settings-setup").count()).toBe(1)
+    expect(renderer.getPaintedText().join("\n")).toContain("esc")
+    expect(renderer.getPaintedText().join("\n")).not.toContain("⎋")
+
+    await app.getByTestId("settings-done").click()
+    await settle()
+    expect(await app.getByTestId("settings-page").count()).toBe(0)
+
+    await app.close()
+  })
+
+  it("keeps a prompt that nothing can answer, and does not hide it behind settings", async () => {
+    const key = process.env.AI_GATEWAY_API_KEY
+    delete process.env.AI_GATEWAY_API_KEY
+    try {
+      setState((current) => ({ ...current, apiKey: null, useCli: false }))
+      const workspace = createWorkspace(tempDir(), "demo")
+      const session = createSession(workspace.id)
+      openSession(session.id, 0)
+
+      await send(session.id, "hello")
+
+      const notices = messagesOf(session.id).filter((message) => message.kind === "notice")
+      expect(messagesOf(session.id).some((message) => message.kind === "user")).toBe(true)
+      expect(notices).toHaveLength(1)
+      expect(notices[0]).toMatchObject({ text: NO_CREDENTIAL, action: "settings" })
+      expect(getState().settingsOpen).toBe(false)
+      expect(findSession(getState(), session.id)?.status).toBe("error")
+
+      await send(session.id, "hello again")
+      expect(messagesOf(session.id).filter((message) => message.kind === "notice")).toHaveLength(1)
+    } finally {
+      if (key === undefined) delete process.env.AI_GATEWAY_API_KEY
+      else process.env.AI_GATEWAY_API_KEY = key
+    }
   })
 
   it("grows the composer when the draft wraps, keeping the first line off the top edge", async () => {

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -60,20 +60,22 @@ while the other dims.
 ### Notices
 
 The app's own messages, like a stop reason or a catalogue that would not load,
-sit in the transcript. They are the one kind of row you can dismiss: click one,
-or use *Clear notices* for a screenful. A request the provider turns down shows
-here as an error, not as the model's reply. Sign-in state is not among them.
-It belongs to settings, which shows it as it is now rather than as of an hour
-ago.
+sit in the transcript. Dismiss one with the × on the row, or *Clear notices* for
+a screenful. A request the provider turns down shows here as an error, not as
+the model's reply. A missing-credential error stays on the session and offers
+Settings; it does not replace the conversation with the settings page. Sign-in
+state is not among them. It belongs to settings, which shows it as it is now
+rather than as of an hour ago.
 
 ### Settings
 
 The gear in the sidebar footer, `⌘,`, or the palette opens it. It is a full
 page in place of the panes, with the Gateway key, the sign-ins, the model new
 sessions start on, which runtime answers a turn, and the skills and MCP servers
-that are loaded. It reads from disk each time it opens, because a sign-in is a
-file, not something the app's state can derive. Opening a session is how you
-leave it.
+that are loaded. Esc or Done leaves it; opening a session does too. It reads
+from disk each time it opens, because a sign-in is a file, not something the
+app's state can derive. If nothing can answer yet, a banner at the top of the
+page says so.
 
 ### Approvals
 
@@ -118,7 +120,9 @@ a key, since none of it could be spent. Subscription catalogues are read at
 startup and the whole list is saved with the rest of the state, so a relaunch
 opens the picker on what it had instead of on nothing while three requests
 land. Switching a model checkpoints the conversation and restores it into a
-new agent, because the model is a creation option.
+new agent, because the model is a creation option. With no key and no
+subscription, the picker says *No model* instead of naming a Gateway default
+that could not run.
 
 ### What a new session starts on
 
@@ -129,11 +133,14 @@ effort and fast tier together, since a model id without the provider that
 serves it routes nowhere. The first session in a workspace has nothing to
 follow, so it opens on a signed-in subscription's own model, the first its
 catalogue lists (which is also the first the picker shows). It falls back to
-`poolside/laguna-s-2.1-free` on the Gateway only when no subscription is signed
-in. Neither provider publishes which model it considers the default, so the
-order they list them in is the only thing to go on. Whichever rule applies, a
-model nothing could answer with is skipped: a Gateway model with no key in hand
-gives way to a subscription.
+`poolside/laguna-s-2.1-free` on the Gateway only when a key is in hand and no
+subscription is signed in. Neither provider publishes which model it considers
+the default, so the order they list them in is the only thing to go on.
+Whichever rule applies, a model nothing could answer with is skipped: a
+Gateway model with no key in hand gives way to a subscription. A new session
+with nothing to answer on shows *Nothing can answer yet* in the pane. Sending
+a prompt keeps the message on the transcript with a Settings action, instead of
+replacing the conversation with the settings page.
 
 ### Reasoning effort
 

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -19,7 +19,7 @@ import {
   notice,
   removeMessage,
   sessionModel,
-  setSettings,
+  NO_CREDENTIAL,
   updateSession,
 } from "../store"
 import {
@@ -223,9 +223,7 @@ async function runtimeFor(sessionId: string): Promise<Runtime> {
     updateSession(sessionId, (current) => ({ ...current, context: { ...current.context, used } })),
   )
   if (!back) {
-    throw new MissingApiKeyError(
-      "This session has no credential. Add an AI Gateway API key, or pick a model from a subscription you are signed in to.",
-    )
+    throw new MissingApiKeyError(NO_CREDENTIAL)
   }
 
   const existing = runtimes.get(sessionId)
@@ -411,6 +409,30 @@ export async function send(
   const trimmed = prompt.trim()
   if (!trimmed && images.length === 0) return
 
+  if (!backing(findSession(getState(), sessionId))) {
+    const isFirstTurn = !findSession(getState(), sessionId)?.messages.some(
+      (message) => message.kind === "user",
+    )
+    appendMessage(sessionId, {
+      id: newId(),
+      kind: "user",
+      at: Date.now(),
+      text: trimmed,
+      ...(images.length > 0 ? { images } : {}),
+    })
+    updateSession(sessionId, (session) => ({
+      ...session,
+      status: "error",
+      title: isFirstTurn ? fallbackTitle(trimmed) : session.title,
+    }))
+    const session = findSession(getState(), sessionId)
+    const already = session?.messages.some(
+      (message) => message.kind === "notice" && message.text === NO_CREDENTIAL,
+    )
+    if (!already) notice(sessionId, "error", NO_CREDENTIAL, "settings")
+    return
+  }
+
   const isFirstTurn = !findSession(getState(), sessionId)?.messages.some(
     (message) => message.kind === "user",
   )
@@ -485,9 +507,8 @@ export async function send(
     stream.flush()
     const message =
       error instanceof Error ? error.message : "The turn failed for an unknown reason."
-    notice(sessionId, "error", message)
+    notice(sessionId, "error", message, error instanceof MissingApiKeyError ? "settings" : undefined)
     updateSession(sessionId, (session) => ({ ...session, status: "error" }))
-    if (error instanceof MissingApiKeyError) setSettings(true)
   } finally {
     denyPendingApprovals(sessionId)
     dismissPendingQuestions(sessionId)

--- a/src/agent/backing.ts
+++ b/src/agent/backing.ts
@@ -2,6 +2,7 @@ import { cliRuntime } from "./cli"
 import { providerFetch, type SearchStep } from "./providers"
 import {
   DEFAULT_MODEL,
+  canAnswer,
   getState,
   nativeSearch,
   setLimits,
@@ -26,10 +27,9 @@ export function backing(
   onUsage?: (tokens: number) => void,
 ): Backing | null {
   const state = getState()
-  if (!session) return null
+  if (!session || !canAnswer(state, session)) return null
 
   const provider = session.provider
-  if (!state.apiKey && !state.useCli && !provider) return null
 
   const search = nativeSearch(state, session)
   const model = session.model ?? (state.useCli ? null : DEFAULT_MODEL.id)

--- a/src/store.ts
+++ b/src/store.ts
@@ -60,6 +60,7 @@ export type Message =
       at: number
       tone: "info" | "error"
       text: string
+      action?: "settings"
     }
 
 export type Context = {
@@ -127,6 +128,9 @@ export const DEFAULT_MODEL: Model = {
   id: "poolside/laguna-s-2.1-free",
   name: "Laguna S 2.1 Free",
 }
+
+export const NO_CREDENTIAL =
+  "This session has no credential. Add an AI Gateway API key, or pick a model from a subscription you are signed in to."
 
 export type Dialog =
   | { kind: "add-workspace"; value: string; error: string | null }
@@ -359,8 +363,20 @@ export function appendMessage(sessionId: string, message: Message): void {
   }))
 }
 
-export function notice(sessionId: string, tone: "info" | "error", text: string): void {
-  appendMessage(sessionId, { id: newId(), kind: "notice", at: Date.now(), tone, text })
+export function notice(
+  sessionId: string,
+  tone: "info" | "error",
+  text: string,
+  action?: "settings",
+): void {
+  appendMessage(sessionId, {
+    id: newId(),
+    kind: "notice",
+    at: Date.now(),
+    tone,
+    text,
+    ...(action ? { action } : {}),
+  })
 }
 
 export function removeMessage(sessionId: string, messageId: string): void {
@@ -434,6 +450,11 @@ type StartsOn = Pick<
 
 function answerable(current: AppState, provider: "grok" | "codex" | null): boolean {
   return provider !== null || apiKeySource(current) !== "none"
+}
+
+export function canAnswer(current: AppState, session: Session | null): boolean {
+  if (!session) return false
+  return Boolean(current.apiKey) || current.useCli || session.provider !== null
 }
 
 function firstSubscription(current: AppState): Chosen | null {

--- a/src/views/composer/index.tsx
+++ b/src/views/composer/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 
 import { color, columnFor, FONT, nativeTheme, radius, space, text } from "../../ui/theme"
 import { IconButton, Thumbnail } from "../../ui/ui"
-import { setAttachments, useApp, type Session } from "../../store"
+import { canAnswer, setAttachments, useApp, type Session } from "../../store"
 import { CAN_PICK_IMAGES } from "../../workspace/images"
 import { ContextMeter } from "./context"
 import {
@@ -54,9 +54,11 @@ export function Composer({
   const { column, gutter } = columnFor(paneWidth)
   const [draft, setDraft] = useState("")
   const picker = useTokenPicker(draft, setDraft, root)
+  const state = useApp()
   const running = session.status === "running"
-  const attached = useApp().attachments[session.id] ?? []
+  const attached = state.attachments[session.id] ?? []
   const ready = (draft.trim().length > 0 || attached.length > 0) && !running
+  const readyToAnswer = canAnswer(state, session)
 
   const tight = column < 340
   const oneRow = fitsOneRow(draft, column)
@@ -192,7 +194,13 @@ export function Composer({
           <textarea
             testId="composer"
             value={draft}
-            placeholder={running ? "Running · ⌘. to stop" : "Ask fx to change something"}
+            placeholder={
+              running
+                ? "Running · ⌘. to stop"
+                : readyToAnswer
+                  ? "Ask fx to change something"
+                  : "Add a key in Settings to send"
+            }
             minRows={1}
             maxRows={12}
             autoFocus

--- a/src/views/composer/pickers.tsx
+++ b/src/views/composer/pickers.tsx
@@ -15,6 +15,7 @@ import { forgetGrants, stopBackgroundCommand } from "../../tools"
 import { attachImages, chooseImages, pasteImage } from "../../workspace/images"
 import {
   DEFAULT_MODEL,
+  canAnswer,
   sessionModel,
   updateSession,
   useApp,
@@ -75,15 +76,24 @@ const Chip = forwardRef<
 })
 
 export function ModelPicker({ session, compact }: { session: Session; compact: boolean }) {
+  const state = useApp()
+  const ready = canAnswer(state, session)
+  const implied =
+    session.model != null
+      ? {
+          id: session.model,
+          provider: session.provider,
+          name: session.modelName,
+        }
+      : ready
+        ? { id: DEFAULT_MODEL.id, provider: null, name: DEFAULT_MODEL.name }
+        : null
+
   return (
     <ModelChoice
       testId="model-picker"
-      value={keyOf({
-        id: session.model ?? DEFAULT_MODEL.id,
-        provider: session.provider,
-        name: null,
-      })}
-      label={session.modelName ?? DEFAULT_MODEL.name}
+      value={implied ? keyOf(implied) : null}
+      label={implied?.name ?? "No model"}
       maxWidth={compact ? 160 : 320}
       size={text.micro}
       onChange={(chosen) => {

--- a/src/views/settings.tsx
+++ b/src/views/settings.tsx
@@ -23,6 +23,7 @@ import { loadSkills } from "../workspace/skills"
 import {
   DEFAULT_MODEL,
   DIR,
+  apiKeySource,
   findSession,
   findWorkspace,
   setSettings,
@@ -41,7 +42,7 @@ import {
   titlebarBand,
   TRAFFIC_LIGHT_INSET,
 } from "../ui/theme"
-import { Button, Label, Paragraph, TextField } from "../ui/ui"
+import { Button, Kbd, Label, Paragraph, TextField } from "../ui/ui"
 
 type Server = ReturnType<typeof listMcpServers>[number]
 
@@ -51,6 +52,36 @@ type Loaded = {
   skills: string[]
   servers: Server[]
   cli: ProviderId[]
+}
+
+function needsSetup(state: AppState): boolean {
+  return !state.useCli && apiKeySource(state) === "none" && state.accounts.length === 0
+}
+
+function SetupBanner({ state }: { state: AppState }) {
+  if (!needsSetup(state)) return null
+  return (
+    <div
+      testId="settings-setup"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: space.sm,
+        padding: space.lg,
+        borderRadius: radius.md,
+        borderWidth: 1,
+        borderColor: color.border,
+        minWidth: 0,
+      }}
+    >
+      <Label size={text.small} color={color.text}>
+        Nothing can answer a prompt yet
+      </Label>
+      <Paragraph size={text.micro} color={color.ghost}>
+        Paste an AI Gateway key or sign in to Grok or Codex below.
+      </Paragraph>
+    </div>
+  )
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -504,6 +535,7 @@ export function Settings({ state }: { state: AppState }) {
         minWidth: 0,
       }}
     >
+      <SetupBanner state={state} />
       <Section title="Models">
         <ApiKeyRow state={state} />
         {(["grok", "codex"] as const).map((provider) => (
@@ -662,7 +694,8 @@ export function SettingsPage({
         <Label size={text.micro} color={color.ghost}>
           Saved as you go
         </Label>
-        <Button label="Done" size="sm" hint="⎋" onClick={() => setSettings(false)} />
+        <Kbd keys="esc" />
+        <Button label="Done" size="sm" testId="settings-done" onClick={() => setSettings(false)} />
       </div>
 
       <div

--- a/src/views/transcript/index.tsx
+++ b/src/views/transcript/index.tsx
@@ -5,10 +5,13 @@ import { type IconName } from "../../ui/icons"
 import { color, columnFor, FONT, space, text } from "../../ui/theme"
 import { Button, Kbd, Label, Paragraph } from "../../ui/ui"
 import {
+  canAnswer,
+  setSettings,
   startSession,
   type Message,
   type Session,
   type Workspace,
+  useApp,
 } from "../../store"
 import { Approval, Question } from "./blocking"
 import { AssistantMessage, Notice, UserMessage } from "./messages"
@@ -203,8 +206,23 @@ export function Transcript({
   const copyable = copyableIds(rows, session.status === "running")
   const [heldAt, setHeldAt] = useState<number | null>(null)
   const holdTail = () => setHeldAt(rows.length)
+  const ready = canAnswer(useApp(), session)
 
   if (session.messages.length === 0) {
+    if (!ready) {
+      return (
+        <EmptyState
+          title="Nothing can answer yet"
+          description="Add an AI Gateway key, or sign in to Grok or Codex."
+          action={{
+            label: "Open settings",
+            icon: "settings",
+            onClick: () => setSettings(true),
+            testId: "empty-setup",
+          }}
+        />
+      )
+    }
     return (
       <div
         style={{

--- a/src/views/transcript/messages.tsx
+++ b/src/views/transcript/messages.tsx
@@ -3,9 +3,9 @@ import { useContext, useState } from "react"
 
 import { Icon } from "../../ui/icons"
 import { color, FONT, nativeTheme, radius, space, text } from "../../ui/theme"
-import { IconButton, Label, Thumbnail } from "../../ui/ui"
+import { Button, IconButton, Label, Thumbnail } from "../../ui/ui"
 import { openExternally } from "../../agent/oauth"
-import { removeMessage, type Message } from "../../store"
+import { removeMessage, setSettings, type Message } from "../../store"
 import { GUTTER, Gutter, HoldTail, Row } from "./shared"
 
 const IMAGE_SIZE = 80
@@ -179,16 +179,13 @@ export function Notice({
     <Row>
       <div
         testId={`notice-${message.id}`}
-        onClick={() => removeMessage(sessionId, message.id)}
         style={{
           display: "flex",
           flexDirection: "row",
           alignItems: "flex-start",
           gap: space.md,
-          paddingRight: space.md,
+          paddingRight: space.xs,
           borderRadius: radius.sm,
-          cursor: "pointer",
-          hover: { backgroundColor: color.hover },
         }}
       >
         <Gutter top={3}>
@@ -210,6 +207,22 @@ export function Notice({
         >
           {message.text}
         </text>
+        {message.action === "settings" ? (
+          <Button
+            label="Settings"
+            size="sm"
+            testId={`notice-settings-${message.id}`}
+            onClick={() => setSettings(true)}
+          />
+        ) : null}
+        <IconButton
+          icon="x"
+          size={18}
+          tooltip="Dismiss"
+          testId={`notice-dismiss-${message.id}`}
+          tone={color.ghost}
+          onClick={() => removeMessage(sessionId, message.id)}
+        />
       </div>
     </Row>
   )


### PR DESCRIPTION
## Summary
- Fixes the Settings **Done** control painting a missing-glyph box (`⎋` is not in SF Mono). It now uses the same `esc` keycap as the empty states. ([#1](https://github.com/zaidmukaddam/fx-ui/issues/1))
- Stops the composer from labelling a session **Laguna S 2.1 Free** when nothing can actually answer. New sessions with no key show **No model**, an empty-state CTA, and a Settings banner. ([#2](https://github.com/zaidmukaddam/fx-ui/issues/2))
- A first prompt with no credential stays on the transcript with a Settings action. Notices dismiss with ×, not a click on the row, so the error cannot vanish by accident. Sending no longer replaces the conversation with Settings.

## Test plan
- [ ] Open Settings with no key. Confirm Done shows an `esc` keycap, not a tofu box. Esc and Done both leave Settings.
- [ ] New session, no Gateway key and no Grok/Codex sign-in: sidebar says No models, composer says No model, pane says Nothing can answer yet.
- [ ] Send a prompt anyway. The user message and error stay on the transcript. Settings does not take over the pane. Click Settings on the notice, add a key or sign in, Done, send again.
- [ ] Click the error text: it does not dismiss. Click ×: it dismisses.
- [ ] Paste a Gateway key, leave Settings: picker shows Laguna S 2.1 Free (or the catalogue) and a prompt runs.
- [ ] `bun run typecheck` and `bun run test`


Made with [Cursor](https://cursor.com)