### PR TITLE
feat: queue prompts while a turn is running

### DIFF
--- a/app.test.tsx
+++ b/app.test.tsx
@@ -18,7 +18,7 @@ import { connectTest } from "@gpuix/react/automation"
 import { createTestRoot, hasNativeTestRenderer } from "@gpuix/react/testing"
 
 import { FxApp } from "./app"
-import { cleanTitle, fallbackTitle, reloadSkills, send } from "./src/agent/agent"
+import { cleanTitle, fallbackTitle, reloadSkills, cancel, send } from "./src/agent/agent"
 import { loadModels, refreshCredentials } from "./src/agent/credentials"
 import { COMPOSER_CARD_INSET } from "./src/views/composer"
 import { gitDiff, gitLog, gitStatus, isClean, summarise } from "./src/workspace/git"
@@ -88,16 +88,19 @@ import {
   clearNotices,
   createSession,
   createWorkspace,
+  enqueuePrompt,
   findSession,
   flushState,
   getState,
   nativeSearch,
   openSession,
+  removeQueued,
   removeWorkspace,
   resetState,
   setSettings,
   setSplit,
   setState,
+  shiftQueue,
   updateSession,
   type Message,
   type PermissionMode,
@@ -713,6 +716,36 @@ describe("git", () => {
 
     const log = await gitLog(root, { limit: 5 })
     expect(log).toContain("first commit")
+  })
+})
+
+describe("queued prompts", () => {
+  it("stores prompts in order and can drop one", () => {
+    const workspace = createWorkspace(tempDir(), "demo")
+    const session = createSession(workspace.id)
+    enqueuePrompt(session.id, "one")
+    enqueuePrompt(session.id, "two", ["/tmp/a.png"])
+
+    expect(getState().queue[session.id]?.map((item) => item.text)).toEqual(["one", "two"])
+    const second = getState().queue[session.id]![1]!
+    removeQueued(session.id, second.id)
+    expect(shiftQueue(session.id)?.text).toBe("one")
+    expect(shiftQueue(session.id)).toBeNull()
+    expect(getState().queue[session.id]).toBeUndefined()
+  })
+
+  it("queues a prompt when the session is already answering", async () => {
+    const workspace = createWorkspace(tempDir(), "demo")
+    const session = createSession(workspace.id)
+    setState((current) => ({ ...current, apiKey: "gateway-key" }))
+    updateSession(session.id, (current) => ({ ...current, status: "running" }))
+
+    await send(session.id, "do this next")
+
+    expect(getState().queue[session.id]?.map((item) => item.text)).toEqual(["do this next"])
+    expect(
+      messagesOf(session.id).some((message) => message.kind === "user" && message.text === "do this next"),
+    ).toBe(false)
   })
 })
 
@@ -3911,6 +3944,106 @@ describeNative("fx app", () => {
     const answer = messagesOf(first.id).find((message) => message.kind === "assistant")
     expect(answer?.kind === "assistant" && answer.text).toContain("done in the background.")
     expect(findSession(getState(), first.id)?.status).toBe("idle")
+    await app.close()
+  })
+
+  it("queues a follow-up and sends it once the turn finishes", async () => {
+    const workspace = createWorkspace(tempDir(), "demo")
+    const session = createSession(workspace.id)
+    openSession(session.id, 0)
+    setState((current) => ({ ...current, apiKey: "gateway-key" }))
+
+    let release = () => {}
+    const answered = new Promise<void>((resolve) => (release = resolve))
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String((input as Request)?.url ?? input)
+      if (!url.includes("/language-model")) return Response.json({ object: "list", data: [] })
+      await answered
+      return new Response(
+        `data: ${JSON.stringify({ type: "text-delta", delta: "done." })}\n\ndata: ${JSON.stringify({ type: "finish", finishReason: { unified: "stop" } })}\n\ndata: [DONE]\n\n`,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      )
+    }) as unknown as typeof fetch
+
+    const until = async (done: () => boolean) => {
+      for (let tries = 0; tries < 200 && !done(); tries += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      }
+    }
+    try {
+      const first = send(session.id, "first")
+      await until(() => findSession(getState(), session.id)?.status === "running")
+      await send(session.id, "second")
+      expect(getState().queue[session.id]?.map((item) => item.text)).toEqual(["second"])
+      release()
+      await first
+    } finally {
+      release()
+      globalThis.fetch = realFetch
+    }
+
+    const users = messagesOf(session.id).filter((message) => message.kind === "user")
+    expect(users.map((message) => message.text)).toEqual(["first", "second"])
+    expect(getState().queue[session.id]).toBeUndefined()
+    expect(findSession(getState(), session.id)?.status).toBe("idle")
+  })
+
+  it("leaves the queue in place when the turn is stopped", async () => {
+    const workspace = createWorkspace(tempDir(), "demo")
+    const session = createSession(workspace.id)
+    openSession(session.id, 0)
+    setState((current) => ({ ...current, apiKey: "gateway-key" }))
+
+    let release = () => {}
+    const answered = new Promise<void>((resolve) => (release = resolve))
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String((input as Request)?.url ?? input)
+      if (!url.includes("/language-model")) return Response.json({ object: "list", data: [] })
+      await answered
+      return new Response(
+        `data: ${JSON.stringify({ type: "text-delta", delta: "done." })}\n\ndata: ${JSON.stringify({ type: "finish", finishReason: { unified: "stop" } })}\n\ndata: [DONE]\n\n`,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      )
+    }) as unknown as typeof fetch
+
+    const until = async (done: () => boolean) => {
+      for (let tries = 0; tries < 200 && !done(); tries += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      }
+    }
+    try {
+      const first = send(session.id, "first")
+      await until(() => findSession(getState(), session.id)?.status === "running")
+      await send(session.id, "second")
+      cancel(session.id)
+      release()
+      await first
+    } finally {
+      release()
+      globalThis.fetch = realFetch
+    }
+
+    expect(messagesOf(session.id).filter((message) => message.kind === "user").map((message) => message.text)).toEqual([
+      "first",
+    ])
+    expect(getState().queue[session.id]?.map((item) => item.text)).toEqual(["second"])
+  })
+
+  it("shows queued prompts and dismisses one", async () => {
+    const workspace = createWorkspace(tempDir(), "demo")
+    const session = createSession(workspace.id)
+    openSession(session.id, 0)
+    enqueuePrompt(session.id, "follow up after this")
+
+    const { renderer, app } = await mount()
+    await app.getByTestId("queue").waitFor()
+    expect(renderer.getPaintedText().join("\n")).toContain("follow up after this")
+
+    const id = getState().queue[session.id]![0]!.id
+    await app.getByTestId(`queue-dismiss-${id}`).click()
+    expect(getState().queue[session.id]).toBeUndefined()
     await app.close()
   })
 

--- a/app.test.tsx
+++ b/app.test.tsx
@@ -3989,6 +3989,48 @@ describeNative("fx app", () => {
     expect(findSession(getState(), session.id)?.status).toBe("idle")
   })
 
+  it.each(["HTTP 401", "HTTP 400", "output limit"])(
+    "keeps queued prompts after a turn ends with %s",
+    async (outcome) => {
+      const workspace = createWorkspace(tempDir(), "demo")
+      const session = createSession(workspace.id)
+      setState((current) => ({ ...current, apiKey: "gateway-key" }))
+      updateSession(session.id, (current) => ({ ...current, title: "Queue failures" }))
+
+      let release = () => {}
+      const answered = new Promise<void>((resolve) => (release = resolve))
+      const realFetch = globalThis.fetch
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String((input as Request)?.url ?? input)
+        if (!url.includes("/language-model")) return Response.json({ object: "list", data: [] })
+        await answered
+        if (outcome.startsWith("HTTP")) {
+          return Response.json({ error: { message: "Request failed" } }, { status: Number(outcome.slice(5)) })
+        }
+        return new Response(
+          `data: ${JSON.stringify({ type: "finish", finishReason: { unified: "length" } })}\n\ndata: [DONE]\n\n`,
+          { headers: { "content-type": "text/event-stream" } },
+        )
+      }) as unknown as typeof fetch
+
+      try {
+        const first = send(session.id, "first")
+        await send(session.id, "second", ["/tmp/queued-image.png"])
+        await send(session.id, "third")
+        release()
+        await first
+
+        expect(messagesOf(session.id).filter((message) => message.kind === "user").map((message) => message.text))
+          .toEqual(["first"])
+        expect(getState().queue[session.id]?.map(({ text, images }) => ({ text, images })))
+          .toEqual([{ text: "second", images: ["/tmp/queued-image.png"] }, { text: "third", images: [] }])
+      } finally {
+        release()
+        globalThis.fetch = realFetch
+      }
+    },
+  )
+
   it("leaves the queue in place when the turn is stopped", async () => {
     const workspace = createWorkspace(tempDir(), "demo")
     const session = createSession(workspace.id)

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -246,9 +246,9 @@ from the last finished turn.
 
 While a turn is running, Enter puts what you typed (and any attached images)
 on a list above the composer instead of sending it. × takes one off. A turn
-that finishes on its own sends the next item; stopping the turn, or a failed
-turn, leaves the list. Enter on an empty composer sends the next one once
-nothing is running.
+that finishes successfully sends the next item; stopping the turn, a failed
+request, a refusal, or hitting the output or step limit leaves the list.
+Enter on an empty composer sends the next one once nothing is running.
 
 ### Copying an answer
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -242,6 +242,14 @@ speech bubble in its place means it is waiting on you, for an approval or an
 answer. A turn does not survive quitting the app: the conversation picks up
 from the last finished turn.
 
+### Queued prompts
+
+While a turn is running, Enter puts what you typed (and any attached images)
+on a list above the composer instead of sending it. × takes one off. A turn
+that finishes on its own sends the next item; stopping the turn, or a failed
+turn, leaves the list. Enter on an empty composer sends the next one once
+nothing is running.
+
 ### Copying an answer
 
 The answer that ends a turn has a copy button under it.

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -12,13 +12,16 @@ import {
   CHECKPOINT_DIR,
   appendMessage,
   appendStreamedText,
+  enqueuePrompt,
   findSession,
   findWorkspace,
+  forgetQueue,
   getState,
   newId,
   notice,
   removeMessage,
   sessionModel,
+  shiftQueue,
   NO_CREDENTIAL,
   updateSession,
 } from "../store"
@@ -52,6 +55,7 @@ type Runtime = {
 }
 
 const runtimes = new Map<string, Runtime>()
+const cancelled = new Set<string>()
 
 const FLUSH_MS = 16
 
@@ -407,7 +411,20 @@ export async function send(
   images: string[] = [],
 ): Promise<void> {
   const trimmed = prompt.trim()
-  if (!trimmed && images.length === 0) return
+  const current = findSession(getState(), sessionId)
+  if (!current) return
+
+  if (current.status === "running") {
+    if (!trimmed && images.length === 0) return
+    enqueuePrompt(sessionId, trimmed, images)
+    return
+  }
+
+  if (!trimmed && images.length === 0) {
+    const next = shiftQueue(sessionId)
+    if (next) await send(sessionId, next.text, next.images)
+    return
+  }
 
   if (!backing(findSession(getState(), sessionId))) {
     const isFirstTurn = !findSession(getState(), sessionId)?.messages.some(
@@ -454,6 +471,8 @@ export async function send(
   const opening = started?.messages.find((message) => message.kind === "user")?.text ?? ""
   const topic = opening || trimmed
   if (topic && started?.title === fallbackTitle(opening)) void nameSession(sessionId, topic)
+
+  cancelled.delete(sessionId)
 
   const stream = new Stream(sessionId)
   try {
@@ -515,9 +534,16 @@ export async function send(
     const workspaceId = findSession(getState(), sessionId)?.workspaceId
     if (workspaceId) void refreshGitStatus(workspaceId)
   }
+
+  const stopped = cancelled.delete(sessionId)
+  if (stopped) return
+  if (findSession(getState(), sessionId)?.status !== "idle") return
+  const next = shiftQueue(sessionId)
+  if (next) await send(sessionId, next.text, next.images)
 }
 
 export function cancel(sessionId: string): void {
+  cancelled.add(sessionId)
   denyPendingApprovals(sessionId)
   runtimes.get(sessionId)?.turn?.cancel()
 }
@@ -569,6 +595,7 @@ export async function closeSession(sessionId: string): Promise<void> {
   await disposeRuntime(sessionId, runtime, { checkpoint: false })
   forgetToolResults(sessionId)
   forgetEdits(sessionId)
+  forgetQueue(sessionId)
   stopBackgroundCommands(sessionId)
 }
 

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -475,6 +475,7 @@ export async function send(
   cancelled.delete(sessionId)
 
   const stream = new Stream(sessionId)
+  let completed = false
   try {
     const runtime = await runtimeFor(sessionId)
 
@@ -522,6 +523,7 @@ export async function send(
     if (outcome) notice(sessionId, "info", outcome)
     updateSession(sessionId, (session) => ({ ...session, status: "idle" }))
     await saveCheckpoint(sessionId, runtime.agent)
+    completed = result.stopReason === "end_turn"
   } catch (error) {
     stream.flush()
     const message =
@@ -536,7 +538,7 @@ export async function send(
   }
 
   const stopped = cancelled.delete(sessionId)
-  if (stopped) return
+  if (stopped || !completed) return
   if (findSession(getState(), sessionId)?.status !== "idle") return
   const next = shiftQueue(sessionId)
   if (next) await send(sessionId, next.text, next.images)

--- a/src/store.ts
+++ b/src/store.ts
@@ -106,6 +106,12 @@ export type BackgroundCommand = {
   exit: number | null
 }
 
+export type QueuedPrompt = {
+  id: string
+  text: string
+  images: string[]
+}
+
 export type Chosen = {
   id: string
   provider: "grok" | "codex" | null
@@ -161,6 +167,7 @@ export type AppState = {
   defaultModel: Chosen | null
   background: Record<string, BackgroundCommand[]>
   attachments: Record<string, string[]>
+  queue: Record<string, QueuedPrompt[]>
   git: Record<string, GitStatus | null>
   limits: Record<string, PlanLimits>
   settingsOpen: boolean
@@ -215,6 +222,7 @@ function emptyState(): AppState {
     defaultModel: null,
     background: {},
     attachments: {},
+    queue: {},
     git: {},
     limits: {},
     settingsOpen: false,
@@ -591,6 +599,7 @@ export function removeSession(sessionId: string): void {
     panes: current.panes.map((pane) =>
       pane.sessionId === sessionId ? { sessionId: null } : pane,
     ),
+    queue: omitQueue(current.queue, sessionId),
   }))
 }
 
@@ -615,6 +624,9 @@ export function removeWorkspace(workspaceId: string): void {
         pane.sessionId && live.has(pane.sessionId)
           ? pane
           : { sessionId: null },
+      ),
+      queue: Object.fromEntries(
+        Object.entries(current.queue).filter(([id]) => live.has(id)),
       ),
     }
   })
@@ -675,6 +687,59 @@ export function setAttachments(sessionId: string, files: string[]): void {
     ...current,
     attachments: { ...current.attachments, [sessionId]: files },
   }))
+}
+
+function omitQueue(
+  queue: Record<string, QueuedPrompt[]>,
+  sessionId: string,
+): Record<string, QueuedPrompt[]> {
+  if (!(sessionId in queue)) return queue
+  const next = { ...queue }
+  delete next[sessionId]
+  return next
+}
+
+export function enqueuePrompt(sessionId: string, text: string, images: string[] = []): void {
+  const item: QueuedPrompt = { id: newId(), text, images }
+  setState((current) => ({
+    ...current,
+    queue: {
+      ...current.queue,
+      [sessionId]: [...(current.queue[sessionId] ?? []), item],
+    },
+  }))
+}
+
+export function removeQueued(sessionId: string, id: string): void {
+  setState((current) => {
+    const rest = (current.queue[sessionId] ?? []).filter((item) => item.id !== id)
+    if (rest.length === (current.queue[sessionId] ?? []).length) return current
+    const queue = { ...current.queue }
+    if (rest.length === 0) delete queue[sessionId]
+    else queue[sessionId] = rest
+    return { ...current, queue }
+  })
+}
+
+export function shiftQueue(sessionId: string): QueuedPrompt | null {
+  let taken: QueuedPrompt | null = null
+  setState((current) => {
+    const [next, ...rest] = current.queue[sessionId] ?? []
+    if (!next) return current
+    taken = next
+    const queue = { ...current.queue }
+    if (rest.length === 0) delete queue[sessionId]
+    else queue[sessionId] = rest
+    return { ...current, queue }
+  })
+  return taken
+}
+
+export function forgetQueue(sessionId: string): void {
+  setState((current) => {
+    if (!(sessionId in current.queue)) return current
+    return { ...current, queue: omitQueue(current.queue, sessionId) }
+  })
 }
 
 export function sessionModel(current: AppState, session: Session | null): Model | null {

--- a/src/views/composer/index.tsx
+++ b/src/views/composer/index.tsx
@@ -1,8 +1,15 @@
 import { useState } from "react"
 
 import { color, columnFor, FONT, nativeTheme, radius, space, text } from "../../ui/theme"
-import { IconButton, Thumbnail } from "../../ui/ui"
-import { canAnswer, setAttachments, useApp, type Session } from "../../store"
+import { IconButton, Label, Thumbnail } from "../../ui/ui"
+import {
+  canAnswer,
+  removeQueued,
+  setAttachments,
+  useApp,
+  type QueuedPrompt,
+  type Session,
+} from "../../store"
 import { CAN_PICK_IMAGES } from "../../workspace/images"
 import { ContextMeter } from "./context"
 import {
@@ -38,6 +45,56 @@ function fitsOneRow(draft: string, column: number): boolean {
   return draft.length <= Math.max(8, perRow)
 }
 
+function queuedLabel(item: QueuedPrompt): string {
+  const line = item.text.trim().split("\n")[0] ?? ""
+  if (line) return line
+  if (item.images.length === 1) return "1 image"
+  if (item.images.length > 1) return `${item.images.length} images`
+  return "Queued"
+}
+
+function Queue({ sessionId, items }: { sessionId: string; items: QueuedPrompt[] }) {
+  if (items.length === 0) return null
+
+  return (
+    <div
+      testId="queue"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: space.xs,
+        paddingTop: space.sm,
+      }}
+    >
+      {items.map((item) => (
+        <div
+          key={item.id}
+          testId={`queue-${item.id}`}
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            gap: space.sm,
+            minWidth: 0,
+          }}
+        >
+          <Label truncate size={text.small} color={color.faint} grow>
+            {queuedLabel(item)}
+          </Label>
+          <IconButton
+            icon="x"
+            size={18}
+            tooltip="Remove from queue"
+            testId={`queue-dismiss-${item.id}`}
+            tone={color.ghost}
+            onClick={() => removeQueued(sessionId, item.id)}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function Composer({
   session,
   root,
@@ -57,7 +114,9 @@ export function Composer({
   const state = useApp()
   const running = session.status === "running"
   const attached = state.attachments[session.id] ?? []
-  const ready = (draft.trim().length > 0 || attached.length > 0) && !running
+  const queued = state.queue[session.id] ?? []
+  const hasContent = draft.trim().length > 0 || attached.length > 0
+  const canSend = hasContent || queued.length > 0
   const readyToAnswer = canAnswer(state, session)
 
   const tight = column < 340
@@ -68,11 +127,22 @@ export function Composer({
       picker.pick(picker.suggestions[picker.highlighted]!.value)
       return
     }
-    if (!ready) return
-    onSend(draft, attached)
-    setAttachments(session.id, [])
-    setDraft("")
-    picker.reset()
+    if (running) {
+      if (!hasContent) return
+      onSend(draft, attached)
+      setAttachments(session.id, [])
+      setDraft("")
+      picker.reset()
+      return
+    }
+    if (hasContent) {
+      onSend(draft, attached)
+      setAttachments(session.id, [])
+      setDraft("")
+      picker.reset()
+      return
+    }
+    if (queued.length > 0) onSend("", [])
   }
 
   const sendAffordance = running ? (
@@ -94,7 +164,7 @@ export function Composer({
       testId="send"
       tooltipSide="top"
       tooltipAlign="end"
-      tone={ready ? color.text : color.ghost}
+      tone={!running && canSend ? color.text : color.ghost}
       onClick={submit}
     />
   )
@@ -147,6 +217,7 @@ export function Composer({
           },
         }}
       >
+        <Queue sessionId={session.id} items={queued} />
         {attached.length > 0 ? (
           <div
             style={{
@@ -196,10 +267,12 @@ export function Composer({
             value={draft}
             placeholder={
               running
-                ? "Running · ⌘. to stop"
-                : readyToAnswer
-                  ? "Ask fx to change something"
-                  : "Add a key in Settings to send"
+                ? "Running · ⏎ to queue"
+                : !hasContent && queued.length > 0
+                  ? "⏎ sends the next queued prompt"
+                  : readyToAnswer
+                    ? "Ask fx to change something"
+                    : "Add a key in Settings to send"
             }
             minRows={1}
             maxRows={12}


### PR DESCRIPTION
## Summary
- Enter during a turn queues the prompt (and attachments) instead of no-oping; × dismisses an item.
- A successful finish sends the next queued prompt; stop or error leaves the list. Empty Enter sends the next item once nothing is running.

Fixes https://github.com/zaidmukaddam/fx-ui/issues/4

## Test plan
- [ ] Start a turn, type a follow-up, press Enter — it appears above the composer, not in the transcript.
- [ ] Let the turn finish — the queued prompt sends on its own.
- [ ] Queue one, press ⌘. — the list stays; Enter with an empty composer sends it.
- [ ] Dismiss a queued row with ×.
- [ ] `bun run typecheck && bun run test && bun run build`