### PR TITLE
feat: bind mcp connections to a workspace by id

### DIFF
--- a/app.test.tsx
+++ b/app.test.tsx
@@ -36,10 +36,17 @@ import {
   addMcpServer,
   authorisedServers,
   beginServerSignIn,
+  connectionsToLoad,
   loadMcp,
+  mcpGrantLabel,
+  mcpGrantScope,
+  pruneMcpGrants,
+  readConnections,
   readMcpConfig,
+  readWorkspaceBindings,
   removeMcpServer,
   resetMcp,
+  setConnectionUsed,
   signOutOfServer,
   storedAuth,
 } from "./src/workspace/mcp"
@@ -1103,6 +1110,7 @@ describe("mcp import", () => {
     expect(saved.mcpServers.existing.futureOption).toBe("keep")
     expect(saved.mcpServers.unknown).toEqual({ futureTransport: "keep" })
     expect(saved.mcpServers.selected.disabled).toBe(true)
+    expect(saved.mcpServers.selected.id).toMatch(/^[0-9a-f]{8}$/)
     expect(saved.mcpServers.ignored).toBeUndefined()
     expect(statSync(target).mode & 0o777).toBe(0o600)
     expect(readFileSync(cursor, "utf8")).toBe(original)
@@ -1412,20 +1420,22 @@ function reply(id, result) {
       })
     })
     await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready))
-    const file = path.join(tempDir(), "mcp.json")
-    writeFileSync(file, JSON.stringify({ mcpServers: { linear: { url: `http://127.0.0.1:${(server.address() as { port: number }).port}/mcp` } } }))
-    const loaded = await acquireMcp(file)
+    mkdirSync(DIR, { recursive: true })
+    const url = `http://127.0.0.1:${(server.address() as { port: number }).port}/mcp`
+    const { session, tools, root } = seed("ask")
+    const file = path.join(DIR, "mcp.json")
+    writeFileSync(file, JSON.stringify({ mcpServers: { linear: { url } } }))
+    const loaded = await acquireMcp(file, root)
     try {
       expect(loaded.problems).toEqual([])
       expect(loaded.tools).toHaveLength(70)
-      const { session, tools } = seed("ask")
       const last = loaded.tools.at(-1)!.tool.name
       expect(await run(tools.capability_search!, { query: "tool_69" })).toContain(last)
       expect(await run(tools.mcp_select_tool!, { name: last })).toContain("mcp_call_tool")
       const denied = run(tools.mcp_call_tool!, { name: last, arguments: { value: "denied" } })
       const rejection = expect(denied).rejects.toThrow(/Denied by the user/)
       const prompt = await waitForApproval(session.id)
-      expect(prompt.scope).toBe("mcp:linear")
+      expect(prompt.scope).toBe(mcpGrantScope("linear", { url }))
       resolveApproval(session.id, prompt.approvalId, "denied")
       await rejection
       expect(calls).toEqual([])
@@ -1476,6 +1486,7 @@ function reply(id, result) {
     } finally {
       await loaded.release()
       await resetMcp()
+      writeFileSync(file, JSON.stringify({ mcpServers: {} }))
       server.close()
     }
   })
@@ -1683,6 +1694,7 @@ function reply(id, result) {
       files: { command: "npx", args: ["-y", "server-filesystem", "/tmp"], env: undefined },
     })
     expect(JSON.parse(readFileSync(file, "utf8")).note).toBe("keep me")
+    expect(JSON.parse(readFileSync(file, "utf8")).mcpServers.linear.id).toMatch(/^[0-9a-f]{8}$/)
 
     expect(() => addMcpServer("linear", "https://x.example/mcp", file)).toThrow(
       /already configured/,
@@ -1778,6 +1790,100 @@ function reply(id, result) {
     expect(loaded.tools).toEqual([])
     expect(loaded.problems[0]?.server).toBe("gone")
     await loaded.close()
+  })
+
+  it("treats a missing id as the display name and writes one on add", () => {
+    const file = path.join(tempDir(), "mcp.json")
+    writeFileSync(file, JSON.stringify({ mcpServers: { linear: { url: "https://mcp.linear.app/mcp" } } }))
+    expect(readConnections(file)).toEqual([
+      { id: "linear", name: "linear", config: { url: "https://mcp.linear.app/mcp", headers: undefined } },
+    ])
+    addMcpServer("github", "https://api.githubcopilot.com/mcp/", file)
+    const github = readConnections(file).find((entry) => entry.name === "github")!
+    expect(github.id).toMatch(/^[0-9a-f]{8}$/)
+    expect(github.id).not.toBe("github")
+  })
+
+  it("loads only the connections bound to that workspace path, without parent merging", async () => {
+    const file = path.join(tempDir(), "mcp.json")
+    writeFileSync(file, JSON.stringify({
+      mcpServers: {
+        here: { id: "id-here", command: "definitely-not-here" },
+        there: { id: "id-there", command: "definitely-not-there" },
+      },
+      workspaceConnections: {
+        "/repo": ["id-here"],
+        "/repo/pkg": [],
+      },
+    }))
+    expect(connectionsToLoad(file).map((entry) => entry.name).sort()).toEqual(["here", "there"])
+    expect(connectionsToLoad(file, "/repo").map((entry) => entry.name)).toEqual(["here"])
+    expect(connectionsToLoad(file, "/repo/pkg")).toEqual([])
+    expect(connectionsToLoad(file, "/other").map((entry) => entry.name).sort()).toEqual(["here", "there"])
+    const loaded = await loadMcp(file, "/repo")
+    expect(loaded.problems.map((entry) => entry.server)).toEqual(["here"])
+    await loaded.close()
+  })
+
+  it("does not start a disabled connection even when the workspace lists it", async () => {
+    const file = path.join(tempDir(), "mcp.json")
+    writeFileSync(file, JSON.stringify({
+      mcpServers: {
+        live: { id: "id-live", command: "definitely-not-live" },
+        paused: { id: "id-paused", command: "definitely-not-paused", disabled: true },
+      },
+      workspaceConnections: { "/repo": ["id-live", "id-paused"] },
+    }))
+    expect(connectionsToLoad(file, "/repo").map((entry) => entry.name)).toEqual(["live"])
+  })
+
+  it("turns implicit all into an explicit list on the first ignore, and keeps new servers out of that list", () => {
+    const file = path.join(tempDir(), "mcp.json")
+    const workspace = "/repo"
+    writeFileSync(file, JSON.stringify({
+      mcpServers: {
+        keep: { id: "id-keep", url: "https://example.invalid/keep" },
+        skip: { id: "id-skip", url: "https://example.invalid/skip" },
+      },
+    }))
+    setConnectionUsed(workspace, "id-skip", false, file)
+    expect(readWorkspaceBindings(file)[workspace]).toEqual(["id-keep"])
+    addMcpServer("extra", "https://example.invalid/extra", file)
+    expect(readWorkspaceBindings(file)[workspace]).toEqual(["id-keep"])
+    const extra = readConnections(file).find((entry) => entry.name === "extra")!
+    setConnectionUsed(workspace, extra.id, true, file)
+    expect(readWorkspaceBindings(file)[workspace]).toEqual(["id-keep", extra.id])
+  })
+
+  it("drops a removed connection from workspace lists", () => {
+    const file = path.join(tempDir(), "mcp.json")
+    writeFileSync(file, JSON.stringify({
+      mcpServers: {
+        keep: { id: "id-keep", url: "https://example.invalid/keep" },
+        gone: { id: "id-gone", url: "https://example.invalid/gone" },
+      },
+      workspaceConnections: { "/a": ["id-keep", "id-gone"], "/b": ["id-gone"] },
+    }))
+    removeMcpServer("gone", file)
+    expect(readWorkspaceBindings(file)).toEqual({ "/a": ["id-keep"], "/b": [] })
+    expect(readConnections(file).map((entry) => entry.name)).toEqual(["keep"])
+  })
+
+  it("scopes MCP grants to the connection id and endpoint, not env or headers", () => {
+    const file = path.join(tempDir(), "mcp.json")
+    const url = "https://mcp.linear.app/mcp"
+    writeFileSync(file, JSON.stringify({ mcpServers: { linear: { id: "lin-1", url, headers: { Authorization: "old" } } } }))
+    const scope = mcpGrantScope("lin-1", { url })
+    expect(scope).toMatch(/^mcp:lin-1:[0-9a-f]{12}$/)
+    expect(mcpGrantScope("lin-1", { url, headers: { Authorization: "new" } })).toBe(scope)
+    expect(mcpGrantScope("lin-1", { url: "https://mcp.linear.app/other" })).not.toBe(scope)
+    expect(mcpGrantScope("lin-1", { command: "npx", args: ["-y", "a"] })).not.toBe(
+      mcpGrantScope("lin-1", { command: "npx", args: ["-y", "b"] }),
+    )
+    expect(mcpGrantLabel(scope, file)).toBe("Use linear tools")
+    expect(pruneMcpGrants(["write", "mcp:linear", scope], file)).toEqual(["write", scope])
+    writeFileSync(file, JSON.stringify({ mcpServers: { linear: { id: "lin-1", url: "https://mcp.linear.app/other" } } }))
+    expect(pruneMcpGrants(["write", scope], file)).toEqual(["write"])
   })
 })
 
@@ -2500,6 +2606,33 @@ process.stdin.on("data", chunk => {
       await app.close()
     }
   }, 20_000)
+
+  it("can ignore an MCP server in this workspace without disabling it", async () => {
+    const { root } = seed()
+    const file = path.join(DIR, "mcp.json")
+    writeFileSync(file, JSON.stringify({
+      mcpServers: {
+        keep: { id: "id-keep", command: "definitely-not-keep" },
+        skip: { id: "id-skip", command: "definitely-not-skip" },
+      },
+    }))
+    setSettings(true)
+    const { renderer, app } = await mount(1100, 900)
+    try {
+      await app.getByTestId("mcp-use-skip").waitFor()
+      const scroll = await app.getByTestId("settings-scroll").bounds()
+      renderer.nativeSimulateScrollWheel(scroll.x + scroll.width / 2, scroll.y + 100, 0, -4_000)
+      renderer.flush()
+      await app.getByTestId("mcp-use-skip").click()
+      await vi.waitFor(() => expect(readWorkspaceBindings(file)[root]).toEqual(["id-keep"]))
+      expect(readMcpConfig(file).skip!.disabled).toBeFalsy()
+      await vi.waitFor(async () => expect(await app.getByTestId("mcp-use-skip").textContent()).toBe("Use here"))
+    } finally {
+      await app.close()
+      await resetMcp()
+      writeFileSync(file, JSON.stringify({ mcpServers: {} }))
+    }
+  })
 
   it("pins a default model from settings, and lets it go back to automatic", async () => {
     const workspace = createWorkspace(tempDir(), "demo")

--- a/app.test.tsx
+++ b/app.test.tsx
@@ -37,6 +37,8 @@ import {
   authorisedServers,
   beginServerSignIn,
   connectionsToLoad,
+  findMcpTool,
+  listMcpTools,
   loadMcp,
   mcpGrantLabel,
   mcpGrantScope,
@@ -1364,15 +1366,24 @@ function reply(id, result) {
     const port = (server.address() as { port: number }).port
 
     const file = path.join(tempDir(), "mcp.json")
+    const endpointFile = path.join(tempDir(), "endpoint")
+    const endpoint = `http://127.0.0.1:${port}/mcp`
+    writeFileSync(endpointFile, endpoint)
     writeFileSync(
       file,
-      JSON.stringify({ mcpServers: { remote: { url: `http://127.0.0.1:${port}/mcp` } } }),
+      JSON.stringify({ mcpServers: { remote: { url: `\${file:${endpointFile}}` } } }),
     )
 
     const loaded = await loadMcp(file)
     try {
       expect(loaded.problems).toEqual([])
       expect(loaded.names).toEqual(["remote"])
+      const scope = mcpGrantScope("remote", { url: endpoint })
+      expect(loaded.tools[0]!.scope).toBe(scope)
+      expect(pruneMcpGrants([scope], file)).toEqual([scope])
+      writeFileSync(endpointFile, `${endpoint}/changed`)
+      expect(pruneMcpGrants([scope], file)).toEqual([])
+      expect(loaded.tools[0]!.scope).toBe(scope)
       const ping = loaded.tools.find((entry) => entry.tool.name.includes("ping"))?.tool
       expect(ping).toBeDefined()
 
@@ -1430,6 +1441,8 @@ function reply(id, result) {
       expect(loaded.problems).toEqual([])
       expect(loaded.tools).toHaveLength(70)
       const last = loaded.tools.at(-1)!.tool.name
+      expect(listMcpTools(`${root}/unloaded-workspace`)).toEqual([])
+      expect(findMcpTool(last, `${root}/unloaded-workspace`)).toBeUndefined()
       expect(await run(tools.capability_search!, { query: "tool_69" })).toContain(last)
       expect(await run(tools.mcp_select_tool!, { name: last })).toContain("mcp_call_tool")
       const denied = run(tools.mcp_call_tool!, { name: last, arguments: { value: "denied" } })
@@ -1506,9 +1519,9 @@ function reply(id, result) {
       return Response.json({ jsonrpc: "2.0", id: message.id, result })
     }) as typeof fetch
     try {
-      const loaded = await acquireMcp(file)
+      const { tools, root } = seed("full-access")
+      const loaded = await acquireMcp(file, root)
       expect(loaded.problems).toEqual([])
-      const { tools } = seed("full-access")
       await expect(run(tools.mcp_select_tool!, { name: "abc" })).rejects.toThrow(/shared by multiple servers/)
       await expect(run(tools.mcp_call_tool!, { name: "abc", arguments: {} })).rejects.toThrow(/shared by multiple servers/)
       expect(calls).toEqual([])
@@ -1869,7 +1882,7 @@ function reply(id, result) {
     expect(readConnections(file).map((entry) => entry.name)).toEqual(["keep"])
   })
 
-  it("scopes MCP grants to the connection id and endpoint, not env or headers", () => {
+  it("scopes MCP grants to the connection id and execution target, not token headers", () => {
     const file = path.join(tempDir(), "mcp.json")
     const url = "https://mcp.linear.app/mcp"
     writeFileSync(file, JSON.stringify({ mcpServers: { linear: { id: "lin-1", url, headers: { Authorization: "old" } } } }))
@@ -1884,6 +1897,49 @@ function reply(id, result) {
     expect(pruneMcpGrants(["write", "mcp:linear", scope], file)).toEqual(["write", scope])
     writeFileSync(file, JSON.stringify({ mcpServers: { linear: { id: "lin-1", url: "https://mcp.linear.app/other" } } }))
     expect(pruneMcpGrants(["write", scope], file)).toEqual(["write"])
+  })
+
+  it("revokes grants when an environment variable changes the resolved endpoint", () => {
+    const file = path.join(tempDir(), "mcp.json")
+    const config = { url: "https://${env:FX_TEST_MCP_HOST}/mcp" }
+    writeFileSync(file, JSON.stringify({ mcpServers: { remote: config } }))
+    try {
+      vi.stubEnv("FX_TEST_MCP_HOST", "first.example")
+      const scope = mcpGrantScope("remote", resolveMcpConfig(config))
+      expect(pruneMcpGrants([scope], file)).toEqual([scope])
+      vi.stubEnv("FX_TEST_MCP_HOST", "second.example")
+      expect(pruneMcpGrants([scope], file)).toEqual([])
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it("revokes local grants when resolved args, command, or working directory change", () => {
+    const file = path.join(tempDir(), "mcp.json")
+    const envFile = path.join(tempDir(), "server.env")
+    const config = { command: "${env:SERVER}", args: ["${env:PROJECT}"], cwd: "${env:ROOT}", envFile }
+    writeFileSync(file, JSON.stringify({ mcpServers: { local: config } }))
+    const original = "SERVER=./server\nPROJECT=one\nROOT=/first\nTOKEN=old\n"
+    writeFileSync(envFile, original)
+    const scope = mcpGrantScope("local", resolveMcpConfig(config))
+    for (const [before, after] of [["./server", "./other"], ["PROJECT=one", "PROJECT=two"], ["/first", "/second"]]) {
+      writeFileSync(envFile, original.replace(before!, after!))
+      expect(pruneMcpGrants([scope], file)).toEqual([])
+    }
+    writeFileSync(envFile, original.replace("TOKEN=old", "TOKEN=new"))
+    expect(pruneMcpGrants([scope], file)).toEqual([scope])
+  })
+
+  it("drops unresolvable grants without blocking other connections", () => {
+    const file = path.join(tempDir(), "mcp.json")
+    const config = { command: "./server", args: [], cwd: "/first" }
+    const scope = mcpGrantScope("local", config)
+    writeFileSync(file, JSON.stringify({ mcpServers: {
+      local: { ...config, envFile: path.join(tempDir(), "missing.env") },
+      remote: { url: "https://example.com/mcp" },
+    } }))
+    const remote = mcpGrantScope("remote", { url: "https://example.com/mcp" })
+    expect(pruneMcpGrants(["write", scope, remote], file)).toEqual(["write", remote])
   })
 })
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -217,10 +217,12 @@ pauses a connection everywhere. Tokens and OAuth stay in `~/.fx-ui`; a
 workspace file that only names connection ids is a later step, and automatic
 `.mcp.json` discovery is not in this version.
 
-A remote server's tools ask before they run. Changing a connection's URL or
-command issues a new approval scope, so an old "always allow" does not follow
-the new endpoint. Env and headers are not part of that check, so rotating a
-token in the file does not revoke the grant.
+A remote server's tools ask before they run. Approval scopes include the
+connection id and its resolved URL, or its resolved command, arguments and
+working directory. Changing those values, including through environment or
+file variables, requires renewed approval. Token-only changes to env or
+headers do not revoke the grant. A connection whose variables cannot be
+resolved loses its old grant without preventing other connections from loading.
 
 Import in the MCP settings row finds global configs from Cursor
 (`~/.cursor/mcp.json`), Devin (`~/.config/devin/mcp_config.json`, or the older

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -205,7 +205,22 @@ workspace beats the same name at home, and `.fx` beats both.
 Settings adds one from a single line: an `https://…` URL for a remote server,
 or the command line that starts a local one. Removing it there takes it out of
 the running sessions as well. Either way it lands in `~/.fx-ui/mcp.json`, which
-stays hand-editable and keeps whatever else you have in it.
+stays hand-editable and keeps whatever else you have in it. Each connection
+gets a stable `id` when you add or import it; older files without one keep
+using the display name as the id. Workspace paths in `workspaceConnections`
+pick which connections that folder uses. A missing entry means every
+connection. An empty list means none. Parent folders are not searched or
+merged. Nothing is read from the repo.
+
+Ignore here in Settings writes that list for the open workspace. Disable still
+pauses a connection everywhere. Tokens and OAuth stay in `~/.fx-ui`; a
+workspace file that only names connection ids is a later step, and automatic
+`.mcp.json` discovery is not in this version.
+
+A remote server's tools ask before they run. Changing a connection's URL or
+command issues a new approval scope, so an old "always allow" does not follow
+the new endpoint. Env and headers are not part of that check, so rotating a
+token in the file does not revoke the grant.
 
 Import in the MCP settings row finds global configs from Cursor
 (`~/.cursor/mcp.json`), Devin (`~/.config/devin/mcp_config.json`, or the older
@@ -249,7 +264,8 @@ catalog is larger than the SDK default. The agent still has at most 64 host
 tool slots: it discovers MCP tools with `capability_search`, reads a schema
 with `mcp_select_tool`, then passes the exact name and arguments to
 `mcp_call_tool`. Server tools stay in the shared MCP pool instead of occupying
-individual agent slots. Calls retain the same per-server approval scope.
+individual agent slots. Calls retain a per-connection approval scope tied to
+that id and endpoint.
 
 ### Images
 
@@ -472,7 +488,7 @@ src/workspace/       the machine a workspace sits on
   skills.ts          skills from .fx, .claude and .agents
   mcp/               connected MCP servers
     index.ts         config to connected tools, and the pool that shares them
-    config.ts        ~/.fx-ui/mcp.json: a command, or a url
+    config.ts        ~/.fx-ui/mcp.json: connections, ids, workspace bindings
     stdio.ts         a server this app spawns
     http.ts          a server it reaches over Streamable HTTP
     auth.ts          the MCP authorization flow, and the tokens it stores

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -40,7 +40,7 @@ import { imageBlock, mentionBlocks } from "../workspace/files"
 import { type ProviderId } from "./oauth"
 import { refreshGitStatus } from "../workspace/git"
 import { loadSkills, splitCommand, type SkillCommand } from "../workspace/skills"
-import { acquireMcp, resetMcp, type McpLease } from "../workspace/mcp"
+import { acquireMcp, MCP_CONFIG_FILE, pruneMcpGrants, resetMcp, type McpLease } from "../workspace/mcp"
 import { beginTurn, endTurn, forgetTurn } from "../workspace/turns"
 
 type Runtime = {
@@ -251,7 +251,8 @@ async function runtimeFor(sessionId: string): Promise<Runtime> {
   }
   if (existing) await disposeRuntime(sessionId, existing, { checkpoint: true })
 
-  const [skills, mcp] = await Promise.all([loadSkills(workspace.path), acquireMcp()])
+  updateSession(sessionId, (current) => ({ ...current, grants: pruneMcpGrants(current.grants) }))
+  const [skills, mcp] = await Promise.all([loadSkills(workspace.path), acquireMcp(MCP_CONFIG_FILE, workspace.path)])
   for (const problem of [
     ...skills.problems.map((entry) => `Skill ${path.basename(entry.file)}: ${entry.reason}`),
     ...mcp.problems.map((entry) => `MCP server ${entry.server}: ${entry.reason}`),
@@ -568,7 +569,7 @@ export async function reloadSkills(): Promise<void> {
   const workspace = findWorkspace(state, findSession(state, focused)?.workspaceId ?? null)
   if (!focused || !workspace) return
 
-  const [skills, mcp] = await Promise.all([loadSkills(workspace.path), acquireMcp()])
+  const [skills, mcp] = await Promise.all([loadSkills(workspace.path), acquireMcp(MCP_CONFIG_FILE, workspace.path)])
   const borrowed = skills.commands.length - skills.names.length
   const found = [
     skills.names.length > 0 ? `skills: ${skills.names.join(", ")}` : "",

--- a/src/tools/extend.ts
+++ b/src/tools/extend.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
-import { findMcpTool, listMcpServers, listMcpTools } from "../workspace/mcp"
+import { findMcpTool, listMcpServers, listMcpTools, MCP_CONFIG_FILE } from "../workspace/mcp"
 import { loadSkills } from "../workspace/skills"
 import {
   adopt,
@@ -135,7 +135,7 @@ export function extensionTools(context: ToolContext): HostTool[] {
             .filter((skill) => matches(`${skill.name} ${skill.description}`))
             .map((skill) => `skill  ${skill.name}: ${skill.description || "no description"}`)
 
-          const servers = listMcpTools()
+          const servers = listMcpTools(ctx.root)
             .filter((tool) => matches(`${tool.name} ${tool.description}`))
             .map((tool) => `mcp    ${tool.name}: ${tool.description}`)
 
@@ -162,8 +162,8 @@ export function extensionTools(context: ToolContext): HostTool[] {
         inputSchema: { type: "object", properties: {} },
         parse: () => ({}),
         label: () => "mcp features",
-        run: async () => {
-          const servers = listMcpServers()
+        run: async (_input, ctx) => {
+          const servers = listMcpServers(MCP_CONFIG_FILE, ctx.root).filter((server) => server.used && !server.disabled)
           if (servers.length === 0) {
             return {
               text: "No MCP servers are connected. They are configured in ~/.fx-ui/mcp.json.",
@@ -196,10 +196,10 @@ export function extensionTools(context: ToolContext): HostTool[] {
         },
         parse: (input) => ({ name: requireString(input, "name") }),
         label: (input) => input.name,
-        run: async (input) => {
-          const tool = findMcpTool(input.name)?.tool
+        run: async (input, ctx) => {
+          const tool = findMcpTool(input.name, ctx.root)?.tool
           if (!tool) {
-            const known = listMcpTools().map((entry) => entry.name)
+            const known = listMcpTools(ctx.root).map((entry) => entry.name)
             throw new Error(
               known.length > 0
                 ? `No MCP tool named ${input.name}. Available: ${known.join(", ")}.`
@@ -238,13 +238,13 @@ export function extensionTools(context: ToolContext): HostTool[] {
         if (!args || typeof args !== "object" || Array.isArray(args)) {
           throw new Error("`arguments` is required and must be an object.")
         }
-        const entry = findMcpTool(name)
+        const entry = findMcpTool(name, context.root)
         if (!entry) throw new Error(`No MCP tool named ${name}. Use capability_search to find an available tool.`)
         if (signal.aborted) throw new Error("cancelled")
         await gate({ ...context, name }, {
           title: `Run ${name}`,
           detail: JSON.stringify(args),
-          scope: `mcp:${entry.server}`,
+          scope: entry.scope,
           denied: `${name} was not run.`,
         })
         if (signal.aborted) throw new Error("cancelled")

--- a/src/views/composer/pickers.tsx
+++ b/src/views/composer/pickers.tsx
@@ -12,6 +12,7 @@ import { Icon } from "../../ui/icons"
 import { color, radius, space, text } from "../../ui/theme"
 import { Button, Explain, Label, overlayStyle } from "../../ui/ui"
 import { forgetGrants, stopBackgroundCommand } from "../../tools"
+import { mcpGrantLabel } from "../../workspace/mcp"
 import { attachImages, chooseImages, pasteImage } from "../../workspace/images"
 import {
   DEFAULT_MODEL,
@@ -404,10 +405,10 @@ function grantLabel(scope: string): string {
   if (scope === "write") return "Edit and create files"
   if (scope === "install_skill") return "Install skills"
   if (scope === "web:search") return "Search the web"
-  const [, kind, target] = /^(cmd|web|mcp):(.+)$/.exec(scope) ?? []
+  if (scope.startsWith("mcp:")) return mcpGrantLabel(scope)
+  const [, kind, target] = /^(cmd|web):(.+)$/.exec(scope) ?? []
   if (kind === "cmd") return `Run ${target}`
   if (kind === "web") return `Fetch from ${target}`
-  if (kind === "mcp") return `Use ${target} tools`
   return scope
 }
 

--- a/src/views/mcp-import.tsx
+++ b/src/views/mcp-import.tsx
@@ -5,7 +5,7 @@ import { getState, HOME_DIR, setState, useApp } from "../store"
 import { useMountEffect } from "../ui/hooks"
 import { color, space, text } from "../ui/theme"
 import { Button, Label, Paragraph } from "../ui/ui"
-import { signOutOfServer } from "../workspace/mcp"
+import { pruneMcpGrants, signOutOfServer } from "../workspace/mcp"
 import { isRemote } from "../workspace/mcp/config"
 import { discoverMcpImports, importMcpServers, sameMcpImport, type McpImportEntry, type McpImportSource } from "../workspace/mcp/import"
 
@@ -34,12 +34,11 @@ export function McpImport({ onClose, onChanged }: { onClose: () => void; onChang
     try {
       const imported = importMcpServers(selected)
       for (const name of imported.imported) signOutOfServer(name)
-      const scopes = new Set(imported.imported.map((name) => `mcp:${name}`))
       setState((current) => ({
         ...current,
         sessions: current.sessions.map((session) => ({
           ...session,
-          grants: session.grants.filter((grant) => !scopes.has(grant)),
+          grants: pruneMcpGrants(session.grants),
         })),
       }))
       setResult(`Imported ${imported.imported.length} server${imported.imported.length === 1 ? "" : "s"}.${imported.skipped.length ? ` Skipped ${imported.skipped.length} already configured or unavailable.` : ""}`)

--- a/src/views/settings.tsx
+++ b/src/views/settings.tsx
@@ -9,7 +9,10 @@ import {
   addMcpServer,
   beginServerSignIn,
   listMcpServers,
+  MCP_CONFIG_FILE,
+  readWorkspaceBindings,
   removeMcpServer,
+  setConnectionUsed,
   setMcpDisabled,
   signOutOfServer,
 } from "../workspace/mcp"
@@ -233,7 +236,13 @@ function ApiKeyRow({ state }: { state: AppState }) {
   )
 }
 
-function AddMcpServerRow({ onChanged }: { onChanged: () => void }) {
+function AddMcpServerRow({
+  workspacePath,
+  onChanged,
+}: {
+  workspacePath: string | null
+  onChanged: () => void
+}) {
   const [name, setName] = useState<string | null>(null)
   const [source, setSource] = useState("")
   const [error, setError] = useState<string | null>(null)
@@ -246,8 +255,13 @@ function AddMcpServerRow({ onChanged }: { onChanged: () => void }) {
   }
 
   const save = () => {
+    const trimmed = (name ?? "").trim()
     try {
-      addMcpServer(name ?? "", source)
+      addMcpServer(trimmed, source)
+      if (workspacePath && readWorkspaceBindings()[workspacePath]) {
+        const added = listMcpServers().find((server) => server.name === trimmed)
+        if (added) setConnectionUsed(workspacePath, added.id, true)
+      }
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : String(reason))
       return
@@ -315,10 +329,12 @@ function AddMcpServerRow({ onChanged }: { onChanged: () => void }) {
 function McpServerRow({
   server,
   running,
+  workspacePath,
   onChanged,
 }: {
   server: Server
   running: boolean
+  workspacePath: string | null
   onChanged: () => void
 }) {
   const [busy, setBusy] = useState(false)
@@ -328,7 +344,7 @@ function McpServerRow({
     setError(null)
     setBusy(true)
     try {
-      const flow = await beginServerSignIn(server.name, expandMcpValue(server.url!), null, openExternally)
+      const flow = await beginServerSignIn(server.id, expandMcpValue(server.url!), null, openExternally)
       await flow.completed
       await reloadSkills()
       onChanged()
@@ -349,6 +365,8 @@ function McpServerRow({
       ? "Waiting for the browser to finish the sign-in."
       : server.disabled
         ? "Disabled. This server will not connect until enabled."
+      : workspacePath && !server.used
+        ? "Not used in this workspace."
       : server.url
         ? server.signedIn
           ? `${host} · signed in · ${server.tools} tools`
@@ -357,6 +375,27 @@ function McpServerRow({
 
   return (
     <Row title={server.name} detail={detail}>
+      {workspacePath ? (
+        <Button
+          label={server.used ? "Ignore here" : "Use here"}
+          size="sm"
+          variant="ghost"
+          disabled={busy || running}
+          testId={`mcp-use-${server.name}`}
+          onClick={() => {
+            if (busy || getState().sessions.some((session) => session.status === "running")) return
+            setBusy(true)
+            setError(null)
+            try {
+              setConnectionUsed(workspacePath, server.id, !server.used)
+              void reloadSkills().then(onChanged).finally(() => setBusy(false))
+            } catch (reason) {
+              setError(reason instanceof Error ? reason.message : String(reason))
+              setBusy(false)
+            }
+          }}
+        />
+      ) : null}
       {server.url && !server.disabled ? (
         <Button
           label={server.signedIn ? "Sign out" : "Sign in"}
@@ -368,7 +407,7 @@ function McpServerRow({
               void signIn()
               return
             }
-            signOutOfServer(server.name)
+            signOutOfServer(server.id, server.name)
             void reloadSkills().then(onChanged)
           }}
         />
@@ -398,7 +437,7 @@ function McpServerRow({
         disabled={busy}
         testId={`mcp-remove-${server.name}`}
         onClick={() => {
-          signOutOfServer(server.name)
+          signOutOfServer(server.id, server.name)
           removeMcpServer(server.name)
           void reloadSkills().then(onChanged)
         }}
@@ -588,7 +627,7 @@ export function Settings({ state }: { state: AppState }) {
         fx: version,
         fxStatus: status,
         skills: skills.names,
-        servers: listMcpServers(),
+        servers: listMcpServers(MCP_CONFIG_FILE, workspace?.path),
         cli: (["grok", "codex"] as const).filter(cliSignedIn),
       })
     })()
@@ -701,8 +740,10 @@ export function Settings({ state }: { state: AppState }) {
               ? "Reading…"
               : loaded.servers.length > 0
                 ? running
-                  ? "Wait for running turns to finish before importing, enabling, or disabling servers."
-                  : "Configured in ~/.fx-ui/mcp.json, never from a workspace. A remote server's tools ask before they run."
+                  ? "Wait for running turns to finish before importing, enabling, or changing which servers this workspace uses."
+                  : workspace
+                    ? "Saved in ~/.fx-ui/mcp.json. Ignore here keeps a connection out of this workspace. Tokens stay in your home folder, not in the repo."
+                    : "Saved in ~/.fx-ui/mcp.json. Open a workspace to choose which connections it uses."
                 : "None configured. Add them to ~/.fx-ui/mcp.json: a `command` for a local one, a `url` for a remote one."
           }
           expanded={importing ? <McpImport onClose={() => setImporting(false)} onChanged={changed} /> : null}
@@ -711,13 +752,14 @@ export function Settings({ state }: { state: AppState }) {
         </Row>
         {(loaded?.servers ?? []).map((server) => (
           <McpServerRow
-            key={server.name}
+            key={server.id}
             server={server}
             running={running}
+            workspacePath={workspace?.path ?? null}
             onChanged={changed}
           />
         ))}
-        <AddMcpServerRow onChanged={changed} />
+        <AddMcpServerRow workspacePath={workspace?.path ?? null} onChanged={changed} />
       </Section>
 
       <Section title="About">

--- a/src/workspace/mcp/auth.ts
+++ b/src/workspace/mcp/auth.ts
@@ -28,11 +28,15 @@ export function authorisedServers(): string[] {
   return Object.keys(store.read())
 }
 
-export function signOutOfServer(server: string): void {
+export function signOutOfServer(...keys: string[]): void {
   const current = store.read()
-  if (!(server in current)) return
-  delete current[server]
-  store.write(current)
+  let changed = false
+  for (const key of new Set(keys.filter(Boolean))) {
+    if (!(key in current)) continue
+    delete current[key]
+    changed = true
+  }
+  if (changed) store.write(current)
 }
 
 function save(server: string, auth: ServerAuth): void {

--- a/src/workspace/mcp/config.ts
+++ b/src/workspace/mcp/config.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { parse, type ParseError } from "jsonc-parser"
 
 import { DIR, newId } from "../../store"
+import { resolveMcpConfig } from "./variables"
 
 export const MCP_CONFIG_FILE = path.join(DIR, "mcp.json")
 
@@ -94,19 +95,28 @@ export function connectionsToLoad(file = MCP_CONFIG_FILE, workspacePath?: string
   return all.filter((connection) => allowed.has(connection.id))
 }
 
-export function connectionFingerprint(config: ServerConfig): string {
-  const material = isRemote(config)
-    ? `url:${config.url}`
-    : `cmd:${config.command}\0${config.args.join("\0")}`
+export function connectionFingerprint(resolved: ServerConfig): string {
+  const material = isRemote(resolved)
+    ? JSON.stringify(["url", resolved.url])
+    : JSON.stringify(["cmd", resolved.command, resolved.args, path.resolve(resolved.cwd ?? process.cwd())])
   return createHash("sha256").update(material).digest("hex").slice(0, 12)
 }
 
-export function mcpGrantScope(id: string, config: ServerConfig): string {
-  return `mcp:${id}:${connectionFingerprint(config)}`
+// Use the same resolved configuration snapshot that opens the connection.
+export function mcpGrantScope(id: string, resolved: ServerConfig): string {
+  return `mcp:${id}:${connectionFingerprint(resolved)}`
 }
 
 export function liveMcpGrantScopes(file = MCP_CONFIG_FILE): Set<string> {
-  return new Set(readConnections(file).map((connection) => mcpGrantScope(connection.id, connection.config)))
+  const scopes = new Set<string>()
+  for (const connection of readConnections(file)) {
+    try {
+      scopes.add(mcpGrantScope(connection.id, resolveMcpConfig(connection.config)))
+    } catch {
+      // An unresolvable connection cannot retain approval; loadMcp reports its error.
+    }
+  }
+  return scopes
 }
 
 export function pruneMcpGrants(grants: string[], file = MCP_CONFIG_FILE): string[] {

--- a/src/workspace/mcp/config.ts
+++ b/src/workspace/mcp/config.ts
@@ -1,8 +1,9 @@
+import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { parse, type ParseError } from "jsonc-parser"
 
-import { DIR } from "../../store"
+import { DIR, newId } from "../../store"
 
 export const MCP_CONFIG_FILE = path.join(DIR, "mcp.json")
 
@@ -27,8 +28,120 @@ export type RemoteServer = {
 
 export type ServerConfig = LocalServer | RemoteServer
 
+export type Connection = {
+  id: string
+  name: string
+  config: ServerConfig
+}
+
 export function isRemote(config: ServerConfig): config is RemoteServer {
   return "url" in config
+}
+
+function connectionIdOf(name: string, raw: unknown): string {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const id = (raw as { id?: unknown }).id
+    if (typeof id === "string" && id) return id
+  }
+  return name
+}
+
+function serversOf(document: Record<string, unknown>): Record<string, unknown> {
+  const servers = document.mcpServers
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) return {}
+  return servers as Record<string, unknown>
+}
+
+export function readWorkspaceBindings(file = MCP_CONFIG_FILE): Record<string, string[]> {
+  let document: Record<string, unknown>
+  try {
+    document = readMcpDocument(file)
+  } catch {
+    return {}
+  }
+  const raw = document.workspaceConnections
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {}
+  const out: Record<string, string[]> = {}
+  for (const [workspace, ids] of Object.entries(raw)) {
+    if (!Array.isArray(ids)) continue
+    out[workspace] = ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+  }
+  return out
+}
+
+export function readConnections(file = MCP_CONFIG_FILE): Connection[] {
+  const config = readMcpConfig(file)
+  let document: Record<string, unknown>
+  try {
+    document = readMcpDocument(file)
+  } catch {
+    return Object.entries(config).map(([name, entry]) => ({ id: name, name, config: entry }))
+  }
+  const servers = serversOf(document)
+  return Object.entries(config).map(([name, entry]) => ({
+    id: connectionIdOf(name, servers[name]),
+    name,
+    config: entry,
+  }))
+}
+
+export function connectionsToLoad(file = MCP_CONFIG_FILE, workspacePath?: string): Connection[] {
+  const all = readConnections(file).filter((connection) => !connection.config.disabled)
+  if (!workspacePath) return all
+  const bound = readWorkspaceBindings(file)[workspacePath]
+  if (!bound) return all
+  const allowed = new Set(bound)
+  return all.filter((connection) => allowed.has(connection.id))
+}
+
+export function connectionFingerprint(config: ServerConfig): string {
+  const material = isRemote(config)
+    ? `url:${config.url}`
+    : `cmd:${config.command}\0${config.args.join("\0")}`
+  return createHash("sha256").update(material).digest("hex").slice(0, 12)
+}
+
+export function mcpGrantScope(id: string, config: ServerConfig): string {
+  return `mcp:${id}:${connectionFingerprint(config)}`
+}
+
+export function liveMcpGrantScopes(file = MCP_CONFIG_FILE): Set<string> {
+  return new Set(readConnections(file).map((connection) => mcpGrantScope(connection.id, connection.config)))
+}
+
+export function pruneMcpGrants(grants: string[], file = MCP_CONFIG_FILE): string[] {
+  const live = liveMcpGrantScopes(file)
+  return grants.filter((grant) => !grant.startsWith("mcp:") || live.has(grant))
+}
+
+export function mcpGrantLabel(scope: string, file = MCP_CONFIG_FILE): string {
+  if (!scope.startsWith("mcp:")) return scope
+  const rest = scope.slice(4)
+  const fingerprinted = /^(.+):([0-9a-f]{12})$/.exec(rest)
+  const id = fingerprinted?.[1] ?? rest
+  const found = readConnections(file).find((connection) => connection.id === id || connection.name === id)
+  return `Use ${found?.name ?? id} tools`
+}
+
+export function setConnectionUsed(
+  workspacePath: string,
+  id: string,
+  used: boolean,
+  file = MCP_CONFIG_FILE,
+): void {
+  if (!workspacePath) return
+  const document = readMcpDocument(file)
+  const connections = readConnections(file)
+  const bindings = readWorkspaceBindings(file)
+  const current = bindings[workspacePath]
+  const next = new Set(current ?? connections.map((connection) => connection.id))
+  if (used) {
+    if (connections.some((connection) => connection.id === id)) next.add(id)
+  } else {
+    next.delete(id)
+  }
+  const ordered = connections.filter((connection) => next.has(connection.id)).map((connection) => connection.id)
+  writeMcpDocument({ ...document, workspaceConnections: { ...bindings, [workspacePath]: ordered } }, file)
 }
 
 export function readMcpDocument(file = MCP_CONFIG_FILE): Record<string, unknown> {
@@ -154,15 +267,23 @@ export function addMcpServer(
   const document = readMcpDocument(file)
   const servers = (document.mcpServers ?? {}) as Record<string, unknown>
   if (Object.hasOwn(servers, trimmed)) throw new Error(`${trimmed} is already configured.`)
-  writeMcpDocument({ ...document, mcpServers: { ...servers, [trimmed]: serverFrom(source) } }, file)
+  writeMcpDocument({ ...document, mcpServers: { ...servers, [trimmed]: { id: newId(), ...serverFrom(source) } } }, file)
 }
 
 export function removeMcpServer(name: string, file = MCP_CONFIG_FILE): void {
   const document = readMcpDocument(file)
-  const servers = { ...(document.mcpServers ?? {}) as Record<string, unknown> }
+  const servers = { ...serversOf(document) }
   if (!Object.hasOwn(servers, name)) return
+  const removed = connectionIdOf(name, servers[name])
   delete servers[name]
-  writeMcpDocument({ ...document, mcpServers: servers }, file)
+  const next: Record<string, unknown> = { ...document, mcpServers: servers }
+  if (document.workspaceConnections !== undefined) {
+    const bindings = readWorkspaceBindings(file)
+    next.workspaceConnections = Object.fromEntries(
+      Object.entries(bindings).map(([workspace, ids]) => [workspace, ids.filter((id) => id !== removed)]),
+    )
+  }
+  writeMcpDocument(next, file)
 }
 
 export function setMcpDisabled(name: string, disabled: boolean, file = MCP_CONFIG_FILE): void {

--- a/src/workspace/mcp/http.ts
+++ b/src/workspace/mcp/http.ts
@@ -36,12 +36,14 @@ export class HttpWire implements Wire {
   private initialised = false
 
   constructor(
+    private readonly id: string,
     private readonly name: string,
     private readonly config: RemoteServer,
   ) {}
 
   private async headers(): Promise<Record<string, string>> {
-    const token = await accessTokenFor(this.name)
+    const token = (await accessTokenFor(this.id))
+      ?? (this.name !== this.id ? await accessTokenFor(this.name) : null)
     return {
       ...this.config.headers,
       "content-type": "application/json",

--- a/src/workspace/mcp/import.ts
+++ b/src/workspace/mcp/import.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs"
 import path from "node:path"
 
-import { HOME_DIR } from "../../store"
+import { HOME_DIR, newId } from "../../store"
 import { MCP_CONFIG_FILE, isRemote, readMcpConfig, readMcpDocument, writeMcpDocument, type ServerConfig } from "./config"
 
 export type McpImportEntry = {
@@ -207,7 +207,7 @@ export function importMcpServers(entries: McpImportEntry[], file = MCP_CONFIG_FI
       skipped.push(entry.name)
       continue
     }
-    raw[entry.name] = entry.config
+    raw[entry.name] = { id: newId(), ...entry.config }
     known[entry.name] = entry.config
     imported.push(entry.name)
   }

--- a/src/workspace/mcp/index.ts
+++ b/src/workspace/mcp/index.ts
@@ -2,7 +2,15 @@ import { createMcpAdapter } from "libfx/mcp"
 
 import type { HostTool } from "../../tools"
 import { authorisedServers } from "./auth"
-import { MCP_CONFIG_FILE, isRemote, readMcpConfig, type ServerConfig } from "./config"
+import {
+  MCP_CONFIG_FILE,
+  connectionsToLoad,
+  isRemote,
+  mcpGrantScope,
+  readConnections,
+  readWorkspaceBindings,
+  type Connection,
+} from "./config"
 import { HttpWire, NeedsSignIn } from "./http"
 import { McpSession } from "./session"
 import { StdioWire } from "./stdio"
@@ -11,11 +19,19 @@ import { resolveMcpConfig } from "./variables"
 export {
   MCP_CONFIG_FILE,
   addMcpServer,
+  connectionsToLoad,
   isRemote,
+  mcpGrantLabel,
+  mcpGrantScope,
+  pruneMcpGrants,
+  readConnections,
   readMcpConfig,
+  readWorkspaceBindings,
   removeMcpServer,
+  setConnectionUsed,
   setMcpDisabled,
   serverFrom,
+  type Connection,
   type LocalServer,
   type RemoteServer,
   type ServerConfig,
@@ -29,7 +45,7 @@ export {
 } from "./auth"
 export { NeedsSignIn } from "./http"
 
-export type ServerTool = { server: string; tool: HostTool }
+export type ServerTool = { server: string; id: string; scope: string; tool: HostTool }
 
 export type LoadedMcp = {
   tools: ServerTool[]
@@ -47,14 +63,19 @@ const EMPTY: LoadedMcp = {
   close: async () => {},
 }
 
-function clientFor(name: string, config: ServerConfig): McpSession {
-  return new McpSession(name, isRemote(config) ? new HttpWire(name, config) : new StdioWire(name, config))
+function clientFor(connection: Connection): McpSession {
+  const resolved = resolveMcpConfig(connection.config)
+  return new McpSession(
+    connection.name,
+    isRemote(resolved)
+      ? new HttpWire(connection.id, connection.name, resolved)
+      : new StdioWire(connection.name, resolved),
+  )
 }
 
-export async function loadMcp(file = MCP_CONFIG_FILE): Promise<LoadedMcp> {
-  const config = readMcpConfig(file)
-  const names = Object.keys(config).filter((name) => !config[name]!.disabled)
-  if (names.length === 0) return EMPTY
+export async function loadMcp(file = MCP_CONFIG_FILE, workspacePath?: string): Promise<LoadedMcp> {
+  const connections = connectionsToLoad(file, workspacePath)
+  if (connections.length === 0) return EMPTY
 
   const tools: ServerTool[] = []
   const instructions: string[] = []
@@ -63,23 +84,26 @@ export async function loadMcp(file = MCP_CONFIG_FILE): Promise<LoadedMcp> {
   const closers: (() => Promise<void>)[] = []
 
   await Promise.all(
-    names.map(async (name) => {
+    connections.map(async (connection) => {
       let client: McpSession | null = null
       try {
-        client = clientFor(name, resolveMcpConfig(config[name]!))
+        client = clientFor(connection)
         await client.initialize()
         const adapter = await createMcpAdapter(client, {
-          prefix: name.replace(/[^A-Za-z0-9_-]/g, "_"),
+          prefix: connection.name.replace(/[^A-Za-z0-9_-]/g, "_"),
           maxTools: 1024,
         })
-        for (const tool of adapter.tools as HostTool[]) tools.push({ server: name, tool })
+        const scope = mcpGrantScope(connection.id, connection.config)
+        for (const tool of adapter.tools as HostTool[]) {
+          tools.push({ server: connection.name, id: connection.id, scope, tool })
+        }
         if (adapter.instructions) instructions.push(adapter.instructions)
-        connected.push(name)
+        connected.push(connection.name)
         closers.push(() => adapter.close())
       } catch (error) {
         await client?.close().catch(() => {})
         problems.push({
-          server: name,
+          server: connection.name,
           reason:
             error instanceof NeedsSignIn
               ? "needs you to sign in, from settings"
@@ -112,19 +136,39 @@ export type McpLease = Omit<LoadedMcp, "close"> & {
 
 type Pool = { loaded: Promise<LoadedMcp>; leases: number; live: LoadedMcp | null }
 
-let pool: Pool | null = null
+const pools = new Map<string, Pool>()
 
-export async function acquireMcp(file = MCP_CONFIG_FILE): Promise<McpLease> {
-  if (!pool) pool = { loaded: loadMcp(file), leases: 0, live: null }
-  const current = pool
-  current.leases += 1
+function poolKey(file: string, workspacePath?: string): string {
+  return `${file}\0${workspacePath ?? ""}`
+}
+
+function liveSets(workspacePath?: string): LoadedMcp[] {
+  const all = [...pools.values()].map((pool) => pool.live).filter((live): live is LoadedMcp => live !== null)
+  if (!workspacePath) return all
+  const matched = [...pools.entries()]
+    .filter(([key]) => key.endsWith(`\0${workspacePath}`))
+    .map(([, pool]) => pool.live)
+    .filter((live): live is LoadedMcp => live !== null)
+  return matched.length ? matched : all
+}
+
+export async function acquireMcp(file = MCP_CONFIG_FILE, workspacePath?: string): Promise<McpLease> {
+  const key = poolKey(file, workspacePath)
+  let current = pools.get(key)
+  if (!current) {
+    current = { loaded: loadMcp(file, workspacePath), leases: 0, live: null }
+    pools.set(key, current)
+  }
+  const pool = current
+  pool.leases += 1
 
   let loaded: LoadedMcp
   try {
-    loaded = await current.loaded
-    if (pool === current) current.live = loaded
+    loaded = await pool.loaded
+    if (pools.get(key) === pool) pool.live = loaded
   } catch (error) {
-    current.leases -= 1
+    pool.leases -= 1
+    if (pool.leases <= 0 && pools.get(key) === pool) pools.delete(key)
     throw error
   }
 
@@ -137,47 +181,53 @@ export async function acquireMcp(file = MCP_CONFIG_FILE): Promise<McpLease> {
     release: async () => {
       if (released) return
       released = true
-      current.leases -= 1
-      if (current.leases <= 0 && pool === current) {
-        pool = null
+      pool.leases -= 1
+      if (pool.leases <= 0 && pools.get(key) === pool) {
+        pools.delete(key)
         await loaded.close()
       }
     },
   }
 }
 
-export function listMcpTools(): HostTool[] {
-  return (pool?.live?.tools ?? []).map((entry) => entry.tool)
+export function listMcpTools(workspacePath?: string): HostTool[] {
+  return liveSets(workspacePath).flatMap((live) => live.tools.map((entry) => entry.tool))
 }
 
-export function findMcpTool(name: string): ServerTool | undefined {
-  const matches = pool?.live?.tools.filter((entry) => entry.tool.name === name) ?? []
+export function findMcpTool(name: string, workspacePath?: string): ServerTool | undefined {
+  const matches = liveSets(workspacePath).flatMap((live) => live.tools.filter((entry) => entry.tool.name === name))
   if (matches.length > 1) {
     throw new Error(`MCP tool name ${name} is shared by multiple servers. Rename a server in Settings before calling it.`)
   }
   return matches[0]
 }
 
-export function listMcpServers(file = MCP_CONFIG_FILE): {
+export function listMcpServers(file = MCP_CONFIG_FILE, workspacePath?: string): {
+  id: string
   name: string
   url: string | null
   signedIn: boolean
   disabled: boolean
+  used: boolean
   tools: number
   toolNames: string[]
 }[] {
-  const config = readMcpConfig(file)
+  const connections = readConnections(file)
+  const bound = workspacePath ? readWorkspaceBindings(file)[workspacePath] : undefined
   const authorised = new Set(authorisedServers())
-  const live = pool?.live
-  return Object.entries(config).map(([name, entry]) => {
+  const live = pools.get(poolKey(file, workspacePath))?.live
+    ?? (workspacePath ? undefined : liveSets()[0])
+  return connections.map((connection) => {
     const toolNames = (live?.tools ?? [])
-      .filter((tool) => tool.server === name)
+      .filter((tool) => tool.server === connection.name)
       .map((tool) => tool.tool.name)
     return {
-      name,
-      url: isRemote(entry) ? entry.url : null,
-      signedIn: authorised.has(name),
-      disabled: !!entry.disabled,
+      id: connection.id,
+      name: connection.name,
+      url: isRemote(connection.config) ? connection.config.url : null,
+      signedIn: authorised.has(connection.id) || authorised.has(connection.name),
+      disabled: !!connection.config.disabled,
+      used: !bound || bound.includes(connection.id),
       tools: toolNames.length,
       toolNames,
     }
@@ -185,11 +235,12 @@ export function listMcpServers(file = MCP_CONFIG_FILE): {
 }
 
 export async function resetMcp(): Promise<void> {
-  const current = pool
-  pool = null
-  if (!current) return
-  try {
-    await (await current.loaded).close()
-  } catch {
-  }
+  const closing = [...pools.values()]
+  pools.clear()
+  await Promise.all(closing.map(async (current) => {
+    try {
+      await (await current.loaded).close()
+    } catch {
+    }
+  }))
 }

--- a/src/workspace/mcp/index.ts
+++ b/src/workspace/mcp/index.ts
@@ -64,7 +64,7 @@ const EMPTY: LoadedMcp = {
 }
 
 function clientFor(connection: Connection): McpSession {
-  const resolved = resolveMcpConfig(connection.config)
+  const resolved = connection.config
   return new McpSession(
     connection.name,
     isRemote(resolved)
@@ -87,13 +87,14 @@ export async function loadMcp(file = MCP_CONFIG_FILE, workspacePath?: string): P
     connections.map(async (connection) => {
       let client: McpSession | null = null
       try {
-        client = clientFor(connection)
+        const resolved = resolveMcpConfig(connection.config)
+        const scope = mcpGrantScope(connection.id, resolved)
+        client = clientFor({ ...connection, config: resolved })
         await client.initialize()
         const adapter = await createMcpAdapter(client, {
           prefix: connection.name.replace(/[^A-Za-z0-9_-]/g, "_"),
           maxTools: 1024,
         })
-        const scope = mcpGrantScope(connection.id, connection.config)
         for (const tool of adapter.tools as HostTool[]) {
           tools.push({ server: connection.name, id: connection.id, scope, tool })
         }
@@ -143,13 +144,10 @@ function poolKey(file: string, workspacePath?: string): string {
 }
 
 function liveSets(workspacePath?: string): LoadedMcp[] {
-  const all = [...pools.values()].map((pool) => pool.live).filter((live): live is LoadedMcp => live !== null)
-  if (!workspacePath) return all
-  const matched = [...pools.entries()]
-    .filter(([key]) => key.endsWith(`\0${workspacePath}`))
+  return [...pools.entries()]
+    .filter(([key]) => !workspacePath || key.endsWith(`\0${workspacePath}`))
     .map(([, pool]) => pool.live)
     .filter((live): live is LoadedMcp => live !== null)
-  return matched.length ? matched : all
 }
 
 export async function acquireMcp(file = MCP_CONFIG_FILE, workspacePath?: string): Promise<McpLease> {

--- a/src/workspace/mcp/variables.ts
+++ b/src/workspace/mcp/variables.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { parseEnv } from "node:util"
 
 import { HOME_DIR } from "../../store"
-import { isRemote, type ServerConfig } from "./config"
+import type { ServerConfig } from "./config"
 
 function readSmallFile(file: string): string {
   const stat = statSync(file)
@@ -34,7 +34,7 @@ export function expandMcpValue(value: string, env: NodeJS.ProcessEnv = process.e
 }
 
 export function resolveMcpConfig(config: ServerConfig, env: NodeJS.ProcessEnv = process.env, home = HOME_DIR): ServerConfig {
-  const fileValues = !isRemote(config) && config.envFile
+  const fileValues = !("url" in config) && config.envFile
     ? parseEnv(readSmallFile(expandMcpValue(config.envFile, env, home).replace(/^~(?=\/|$)/, home)))
     : {}
   const fromFile = Object.fromEntries(Object.entries(fileValues).filter((entry): entry is [string, string] => typeof entry[1] === "string"))
@@ -42,7 +42,7 @@ export function resolveMcpConfig(config: ServerConfig, env: NodeJS.ProcessEnv = 
   const expand = (value: string) => expandMcpValue(value, environment, home)
   const fields = (values: Record<string, string> | undefined) =>
     Object.fromEntries(Object.entries(values ?? {}).map(([key, value]) => [key, expand(value)]))
-  if (isRemote(config)) {
+  if ("url" in config) {
     const url = expand(config.url)
     if (!["http:", "https:"].includes(new URL(url).protocol)) throw new Error("An MCP URL must use HTTP or HTTPS.")
     return { ...config, url, headers: fields(config.headers) }


### PR DESCRIPTION
## Summary
- Connections still live only in `~/.fx-ui/mcp.json`. Add and import stamp a stable `id`; older entries without one keep using the display name.
- A workspace can pick which connections it uses (`workspaceConnections` in that same home file). Missing entry means all of them. Empty list means none. Parent folders are not merged. Settings grows Ignore here / Use here for the open folder. Disable still pauses a connection everywhere.
- Tool approvals are `mcp:<id>:<url-or-command hash>`. Changing the URL or command asks again. Env and headers are left out of the hash so rotating a token does not revoke the grant. OAuth tokens are stored by id, with the old name key still accepted.

This is the first slice of https://github.com/zaidmukaddam/fx-ui/issues/6. It does not read `.mcp.json` from the repo, and it does not add env/headers fields to the Settings form.

## Test plan
- [ ] Add two servers in Settings. Ignore here on one; a turn in that workspace only sees the other. A second workspace with no list of its own still sees both.
- [ ] Disable still stops a server in every workspace. Remove drops it from workspace lists.
- [ ] Sign in to a remote server still works for entries that only have a name in `mcp-auth.json`.
- [ ] Allow a tool, change that server's URL in `mcp.json`, reload; the old always-allow does not apply.
- [ ] `bun run typecheck && bun run test && bun run build`


Made with [Cursor](https://cursor.com)